### PR TITLE
Proposal: Add Maintainer Role

### DIFF
--- a/Product/roles/DEVSECOPS_ARCHITECT.md
+++ b/Product/roles/DEVSECOPS_ARCHITECT.md
@@ -1,0 +1,14 @@
+# Accountabilities
+
+*What do we expect this role to do on an on-going basis?*
+
+- shaping the DevOps ecosystem and tooling, including architecting and maintaining a solid SaaS infrastructure and CI/CD pipeline
+- advising clients and developing patterns for deploying self-hosted version(s) of Parabol
+- collaborating with the [Security Officer](./SECURITY_OFFICER.md) to design and implement an ever-improving security posture via automation
+
+# Exclusive Assets
+
+*What does this role have exclusive rights to use or administer (where others would have to seek permission to use or change this thing)?*
+
+- pipeline configurations and any infrastructure provisioned by that configuration
+- underlying infrastructure supporting DevSecOps (for example, managed Kubernetes services)

--- a/Product/roles/MAINTAINER.md
+++ b/Product/roles/MAINTAINER.md
@@ -1,0 +1,18 @@
+# Accountabilities
+
+*What do we expect this role to do on an on-going basis?*
+
+- Reviewing the specifics of the pull request before merging
+
+# Exclusive Assets
+
+*What does this role have exclusive rights to use or administer (where others would have to seek permission to use or change this thing)?*
+
+- Merging pull requests back to any of Parabol's master branches within a related role's area of domain expertise
+
+# Maintainer Related Roles
+|Role Name                                                                               |Domain(s) of Expertise|
+|----------------------------------------------------------------------------------------|----------------------|
+|[DevSecOps Architect](./DEVSECOPS_ARCHITECT.md)                                         |DevOps, Security      |      
+|[Principal Backend Developer](./PRINCIPAL_BACKEND_DEVELOPER.md)                         |Backend               |      
+|[Principal Frontend Developer](./PRINCIPAL_FRONTEND_DEVELOPER.md)                       |Frontend              |      

--- a/Product/roles/PRINCIPAL_BACKEND_DEVELOPER.md
+++ b/Product/roles/PRINCIPAL_BACKEND_DEVELOPER.md
@@ -1,0 +1,8 @@
+# Accountabilities
+
+*What do we expect this role to do on an on-going basis?*
+
+- architecting and implementing backend patterns others can use
+- creating the necessary diagnostic artifices to keep tabs on application performance, bugs, or errors, and forming an opinion on the the areas of greatest need of improvement
+- writing and communicating ideas in the form of specs and stories for our backlog
+- architecting epic-level work and specifies an efficient starting point and Dividing the work in a manner able to be executed on by others

--- a/Product/roles/PRINCIPAL_FRONTEND_DEVELOPER.md
+++ b/Product/roles/PRINCIPAL_FRONTEND_DEVELOPER.md
@@ -1,0 +1,8 @@
+# Accountabilities
+
+*What do we expect this role to do on an on-going basis?*
+
+- Developing reusable UI components and patterns
+- Implementing user interactions according to spec and design
+- Implementing UI views according to spec and design
+- Creating and grooming issues in codebase related to this role

--- a/Product/roles/SECURITY_OFFICER.md
+++ b/Product/roles/SECURITY_OFFICER.md
@@ -1,0 +1,10 @@
+# Accountabilities
+
+- Identifying potential security risks and creating plans to mitigate them
+- Responding to incidents, according to the [Incident Response Playbook](https://www.notion.so/Incident-Response-Playbook-e5206bad0c224c86915d7e503bbb102e)
+- Leading incident post-mortems and sharing outcomes with stakeholders
+
+# Exclusive Assets
+
+- The security@parabol.co inbox
+- Accepting or rejecting security incidents for further triage by the [Parabol – Product](../index.md) team


### PR DESCRIPTION
*Meta: This is just an example of what a proposal would look like in GitHub. It has already been governed.*

I propose a maintainer role be introduced.
That role will be powered by either a devsecops architect, principal frontend dev or principal backend dev.
